### PR TITLE
Jobs MQ leasing + idempotency

### DIFF
--- a/docs/db/jobs_mq.md
+++ b/docs/db/jobs_mq.md
@@ -31,6 +31,16 @@ See: `supabase/migrations/20260313_jobs_mq.sql`
 ### Polling
 Workers should claim jobs using `lease_job(type)` (see SQL function) which uses `FOR UPDATE SKIP LOCKED`.
 
+Leasing behavior:
+- Claims at most one oldest `queued` job for the requested `type`.
+- Uses row-level locking (`FOR UPDATE SKIP LOCKED`) so concurrent workers do not claim the same row.
+- Moves the row to `running`, sets `started_at`, and increments `attempts` atomically.
+
+### Idempotency / dedupe
+- `dedupe_key` is optional and is used by producers to make enqueue idempotent.
+- A partial unique index (`jobs_mq_dedupe_idx`) enforces uniqueness for non-null `dedupe_key` values.
+- If an insert reuses an existing `dedupe_key`, treat the unique violation as "already enqueued".
+
 ### Acknowledgement
 - On claim, set `status=running`, `started_at=now()`, increment `attempts`.
 - On success, set `status=completed`, `completed_at=now()`.

--- a/supabase/migrations/20260313_jobs_mq_lease_idempotency.sql
+++ b/supabase/migrations/20260313_jobs_mq_lease_idempotency.sql
@@ -1,0 +1,36 @@
+-- issue #29: leasing + idempotency guardrails for jobs_mq
+
+-- Ensure dedupe index exists for producer-side idempotency.
+-- `dedupe_key` may be null; uniqueness is enforced only when provided.
+create unique index if not exists jobs_mq_dedupe_idx
+  on public.jobs_mq(dedupe_key)
+  where dedupe_key is not null;
+
+-- Ensure lease function exists and keeps row-level locking semantics.
+create or replace function public.lease_job(job_type text)
+returns setof public.jobs_mq
+language plpgsql
+as $$
+begin
+  return query
+  with job as (
+    select *
+    from public.jobs_mq
+    where status = 'queued' and type = job_type
+    order by created_at asc
+    for update skip locked
+    limit 1
+  )
+  update public.jobs_mq j
+  set status = 'running',
+      started_at = now(),
+      updated_at = now(),
+      attempts = j.attempts + 1
+  from job
+  where j.id = job.id
+  returning j.*;
+end;
+$$;
+
+comment on function public.lease_job(text) is
+'Claims one queued job for a type using FOR UPDATE SKIP LOCKED. Idempotency is enforced at enqueue time via jobs_mq.dedupe_key (unique partial index jobs_mq_dedupe_idx).';


### PR DESCRIPTION
Closes #29.

Adds lease_job idempotency notes + migration for dedupe index/lease function.