### PR TITLE
Storage layer schema + lifecycle docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ This project was created by WoodwardStudio Dev Agent.
 
 - [Roadmap checklist](docs/roadmap.md)
 - [Google Drive import/export PRD](docs/google-drive-import-export-prd.md)
+- [Asset storage layer](docs/storage.md)

--- a/docs/storage.md
+++ b/docs/storage.md
@@ -1,0 +1,120 @@
+# Asset Storage Layer (Supabase Storage / S3-Compatible)
+
+This document defines the storage-layer contract for Issue #24: where asset bytes live, how metadata is stored, how signed URLs are used, and how lifecycle cleanup works.
+
+## Goals
+
+- Support `supabase` and `s3` providers behind the same metadata model.
+- Keep object-store details out of app-facing business logic.
+- Use short-lived signed URLs for upload/download.
+- Provide predictable lifecycle states and cleanup behavior.
+
+## Schema
+
+Canonical SQL migration:
+
+- `supabase/migrations/20260313_assets_storage_layer.sql`
+
+### Table: `public.assets`
+
+Required fields:
+
+- `id uuid` - primary key.
+- `project_id uuid` - project linkage.
+- `provider text` - `supabase` or `s3`.
+- `bucket text` - bucket/container name.
+- `object_key text` - object path/key inside bucket.
+- `size_bytes bigint` - byte length.
+- `mime_type text` - content type.
+- `status text` - `pending|uploading|ready|failed|deleted`.
+
+Optional/operational fields:
+
+- `checksum_sha256 text` - integrity and dedupe checks.
+- `metadata jsonb` - provider-specific or asset-specific metadata.
+- `error jsonb` - failure payload if upload/processing fails.
+- `uploaded_at timestamptz` - finalized upload timestamp.
+- `expires_at timestamptz` - lifecycle expiry for temporary assets.
+- `deleted_at timestamptz` - soft-delete timestamp.
+- `created_at`, `updated_at` - record audit timestamps.
+
+### Constraints and indexes
+
+- Uniqueness: `(provider, bucket, object_key)`.
+- Provider check constraint: `provider in ('supabase', 's3')`.
+- Status check constraint: `pending|uploading|ready|failed|deleted`.
+- Indexed for common patterns:
+  - `project_id`
+  - `status`
+  - `(project_id, status)`
+  - `expires_at` (partial)
+  - `deleted_at` (partial)
+
+## Signed URL Flows
+
+The app/backend should never expose long-lived storage credentials to clients.
+
+### Upload flow (write)
+
+1. Create `assets` row with `status='pending'` and known metadata (`project_id`, `provider`, `bucket`, `object_key`, `mime_type`, optional `size_bytes`).
+2. Backend requests a short-lived signed upload URL from the selected provider.
+3. Client uploads bytes directly to object storage using the signed URL.
+4. Backend verifies object existence (and checksum/size when available), then marks:
+   - `status='ready'`
+   - `uploaded_at=now()`
+   - `size_bytes` / `checksum_sha256` finalized.
+5. On error, mark `status='failed'` and populate `error`.
+
+### Download flow (read)
+
+1. Caller resolves asset metadata from `public.assets`.
+2. Allow reads only for `status='ready'` and non-deleted rows.
+3. Backend issues a short-lived signed download URL.
+4. Client fetches bytes directly from storage.
+
+## Object Key Convention
+
+Recommended key layout:
+
+- `project/<project_id>/uploads/<asset_id>/<filename>`
+- `project/<project_id>/renders/<asset_id>/<filename>`
+- `project/<project_id>/derived/<asset_id>/<variant>`
+
+This keeps project-scoped assets easy to list, migrate, and clean up.
+
+## Lifecycle and Cleanup Policy
+
+### Status lifecycle
+
+- `pending` -> `uploading` -> `ready`
+- `pending|uploading` -> `failed`
+- `ready|failed` -> `deleted` (soft delete in DB, object deleted from storage)
+
+### Cleanup categories
+
+- **Expired temporary assets:** rows with `expires_at < now()` and not already deleted.
+- **Failed stale uploads:** `status='failed'` older than retention window (for example, 7 days).
+- **Soft-deleted assets:** `status='deleted'` where object was already removed; row can be retained for audit or purged after retention.
+
+### Cleanup process (recommended)
+
+1. Select candidate rows (`expires_at`, `status`, `deleted_at`).
+2. Attempt object deletion in provider (`bucket`, `object_key`).
+3. On success, set `status='deleted'`, `deleted_at=now()`.
+4. Optionally hard-delete rows older than audit retention.
+
+Example candidate query for expiration cleanup:
+
+```sql
+select id, provider, bucket, object_key
+from public.assets
+where expires_at is not null
+  and expires_at < now()
+  and status <> 'deleted';
+```
+
+## Provider Notes
+
+- **Supabase Storage:** provider value `supabase`; bucket maps to Supabase storage bucket.
+- **S3-compatible:** provider value `s3`; bucket/object key map to S3 API conventions.
+- Keep provider credentials server-side only; store no secrets in database docs or migrations.

--- a/supabase/migrations/20260313_assets_storage_layer.sql
+++ b/supabase/migrations/20260313_assets_storage_layer.sql
@@ -1,0 +1,48 @@
+-- issue #24: asset storage layer schema (supabase storage / s3)
+
+create table if not exists public.assets (
+  id uuid primary key default gen_random_uuid(),
+  project_id uuid not null,
+  provider text not null check (provider in ('supabase', 's3')),
+  bucket text not null,
+  object_key text not null,
+  size_bytes bigint not null check (size_bytes >= 0),
+  mime_type text not null,
+  checksum_sha256 text,
+  status text not null default 'pending' check (status in ('pending', 'uploading', 'ready', 'failed', 'deleted')),
+  metadata jsonb not null default '{}'::jsonb,
+  error jsonb,
+  expires_at timestamptz,
+  uploaded_at timestamptz,
+  deleted_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint assets_provider_bucket_object_key_uniq unique (provider, bucket, object_key)
+);
+
+create index if not exists assets_project_id_idx on public.assets(project_id);
+create index if not exists assets_status_idx on public.assets(status);
+create index if not exists assets_project_status_idx on public.assets(project_id, status);
+create index if not exists assets_expires_at_idx on public.assets(expires_at) where expires_at is not null;
+create index if not exists assets_deleted_at_idx on public.assets(deleted_at) where deleted_at is not null;
+
+comment on table public.assets is
+'Stores uploaded and derived asset metadata for Supabase Storage and S3-compatible object stores.';
+
+comment on column public.assets.project_id is
+'Logical project linkage. Foreign key can be added once the canonical projects table is finalized.';
+
+comment on column public.assets.provider is
+'Object storage provider identifier. Supported values: supabase, s3.';
+
+comment on column public.assets.object_key is
+'Provider object key/path (for example: project/<project_id>/uploads/<asset_id>.mp4).';
+
+comment on column public.assets.status is
+'Asset lifecycle state: pending -> uploading -> ready, with failed/deleted as terminal states.';
+
+comment on column public.assets.expires_at is
+'Optional expiry for temporary assets or signed URL lifecycle coordination.';
+
+comment on column public.assets.checksum_sha256 is
+'Hex SHA-256 checksum used for integrity validation and dedupe checks.';


### PR DESCRIPTION
Closes #24.

Adds assets table migration and storage lifecycle docs (signed URL flow, cleanup policy).